### PR TITLE
Add basic FastAPI backend for template generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+templates/
+generated/

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from docxtpl import DocxTemplate
+from docx import Document
+import json
+import uuid
+from pathlib import Path
+
+app = FastAPI()
+TEMPLATE_DIR = Path('templates')
+OUTPUT_DIR = Path('generated')
+
+@app.post('/templates')
+async def create_template(style_desc: str = '', hint: str = '', reference: UploadFile | None = None):
+    """Create a blank Word template.
+
+    In a real implementation the style description and optional reference
+    document would influence the produced template.  For now we simply
+    generate an empty template that can be used for JSON merging.
+    """
+    template_path = TEMPLATE_DIR / f"{uuid.uuid4()}.docx"
+    Document().save(template_path)
+    return {'template_id': template_path.stem}
+
+@app.post('/documents/{template_id}')
+async def generate_document(template_id: str, data: UploadFile = File(...)):
+    template_path = TEMPLATE_DIR / f'{template_id}.docx'
+    if not template_path.exists():
+        raise HTTPException(status_code=404, detail='Template not found')
+    context = json.loads(await data.read())
+    tpl = DocxTemplate(template_path)
+    tpl.render(context)
+    out_path = OUTPUT_DIR / f"{template_id}-{uuid.uuid4()}.docx"
+    tpl.save(out_path)
+    return {'document': str(out_path)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic
+python-multipart
+docxtpl
+httpx

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import json
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path as _Path
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+from backend.main import app, TEMPLATE_DIR, OUTPUT_DIR
+
+client = TestClient(app)
+
+def test_create_and_generate(tmp_path):
+    # create template
+    response = client.post('/templates', data={'style_desc': '', 'hint': ''})
+    assert response.status_code == 200
+    template_id = response.json()['template_id']
+    template_path = TEMPLATE_DIR / f'{template_id}.docx'
+    assert template_path.exists()
+
+    # generate document
+    data = {'name': 'Alice'}
+    files = {'data': ('data.json', json.dumps(data), 'application/json')}
+    response = client.post(f'/documents/{template_id}', files=files)
+    assert response.status_code == 200
+    doc_path = Path(response.json()['document'])
+    assert doc_path.exists()
+    # Clean up
+    template_path.unlink()
+    doc_path.unlink()


### PR DESCRIPTION
## Summary
- implement FastAPI service that creates blank Word templates and generates documents from JSON data
- track dependencies for FastAPI and docx utilities
- add test ensuring templates can be created and rendered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2055470c83329fabaa2baa979047