### PR TITLE
feat: modernize frontend layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,70 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background-color: #f4f4f9;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: #ffffff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+input,
+select,
+textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  align-self: flex-start;
+}
+
+button:hover {
+  background-color: #0069d9;
+}
+
+p {
+  background: #e9ecef;
+  padding: 1rem;
+  border-radius: 4px;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import './App.css';
 
 export default function App() {
   const [templateId, setTemplateId] = useState('');
@@ -35,40 +36,40 @@ export default function App() {
   }
 
   return (
-    <div>
+    <div className="container">
       <h1>ERP Document Generator</h1>
 
-      <section>
+      <section className="card">
         <h2>Create Template</h2>
-        <form onSubmit={createTemplate}>
-          <label>
-            Style Description:
-            <input value={styleDesc} onChange={e => setStyleDesc(e.target.value)} />
-          </label>
-          <label>
-            Hint:
-            <select value={hint} onChange={e => setHint(e.target.value)}>
+        <form className="form" onSubmit={createTemplate}>
+          <div className="form-group">
+            <label htmlFor="styleDesc">Style Description</label>
+            <input id="styleDesc" value={styleDesc} onChange={e => setStyleDesc(e.target.value)} />
+          </div>
+          <div className="form-group">
+            <label htmlFor="hint">Hint</label>
+            <select id="hint" value={hint} onChange={e => setHint(e.target.value)}>
               <option value="minimal">Minimal</option>
               <option value="corporate">Corporate</option>
               <option value="modern">Modern</option>
               <option value="classic">Classic</option>
             </select>
-          </label>
+          </div>
           <button type="submit">Create</button>
         </form>
       </section>
 
-      <section>
+      <section className="card">
         <h2>Generate Document</h2>
-        <form onSubmit={generateDocument}>
-          <label>
-            Template ID:
-            <input value={templateId} onChange={e => setTemplateId(e.target.value)} />
-          </label>
-          <label>
-            JSON Data:
-            <textarea rows="6" value={jsonData} onChange={e => setJsonData(e.target.value)} />
-          </label>
+        <form className="form" onSubmit={generateDocument}>
+          <div className="form-group">
+            <label htmlFor="templateId">Template ID</label>
+            <input id="templateId" value={templateId} onChange={e => setTemplateId(e.target.value)} />
+          </div>
+          <div className="form-group">
+            <label htmlFor="jsonData">JSON Data</label>
+            <textarea id="jsonData" rows="6" value={jsonData} onChange={e => setJsonData(e.target.value)} />
+          </div>
           <button type="submit">Generate</button>
         </form>
       </section>


### PR DESCRIPTION
## Summary
- Import and apply new `App.css` styles for a clean, card-based layout
- Refactor forms to use semantic groups with aligned labels and controls

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf7fda05483329a5929fbb9e33d93