### PR TITLE
Generate styled Word templates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
 from docxtpl import DocxTemplate
 from docx import Document
+from docx.shared import Pt
 import json
 import uuid
 from pathlib import Path
@@ -14,17 +17,67 @@ OUTPUT_DIR = Path('generated')
 TEMPLATE_DIR.mkdir(exist_ok=True)
 OUTPUT_DIR.mkdir(exist_ok=True)
 
-@app.post('/templates')
-async def create_template(style_desc: str = '', hint: str = '', reference: UploadFile | None = None):
-    """Create a blank Word template.
+class TemplateRequest(BaseModel):
+    """Request body for creating a template."""
 
-    In a real implementation the style description and optional reference
-    document would influence the produced template.  For now we simply
-    generate an empty template that can be used for JSON merging.
+    style_desc: str = ''
+    hint: str = 'minimal'
+
+
+def _apply_hint_style(doc: Document, hint: str) -> None:
+    """Apply basic styling to the document based on the hint.
+
+    This is a very small demo of what could be a much more powerful styling
+    engine.  The goal is simply to make the produced template visually reflect
+    the selected hint so the user sees that something has happened when the
+    Create button is pressed.
     """
+
+    style = doc.styles['Normal'].font
+    if hint == 'corporate':
+        style.name = 'Calibri'
+        style.size = Pt(12)
+    elif hint == 'modern':
+        style.name = 'Arial'
+        style.size = Pt(11)
+    elif hint == 'classic':
+        style.name = 'Times New Roman'
+        style.size = Pt(12)
+    else:  # minimal
+        style.name = 'Calibri'
+        style.size = Pt(11)
+
+
+@app.post('/templates')
+async def create_template(req: TemplateRequest):
+    """Create a Word template with a very simple style applied.
+
+    The style description and hint roughly determine the fonts used in the
+    generated template so the user can immediately see the effect.
+    """
+
     template_path = TEMPLATE_DIR / f"{uuid.uuid4()}.docx"
-    Document().save(template_path)
-    return {'template_id': template_path.stem}
+    doc = Document()
+    _apply_hint_style(doc, req.hint)
+
+    # Use the style description as a heading if supplied
+    doc.add_heading(req.style_desc or 'Document Title', level=1)
+
+    # Include a simple placeholder so the template can be rendered later
+    doc.add_paragraph('Hello {{ name }}!')
+
+    doc.save(template_path)
+    template_id = template_path.stem
+    return {'template_id': template_id, 'download_url': f'/templates/{template_id}'}
+
+
+@app.get('/templates/{template_id}')
+async def download_template(template_id: str):
+    """Return the generated template for download."""
+    template_path = TEMPLATE_DIR / f'{template_id}.docx'
+    if not template_path.exists():
+        raise HTTPException(status_code=404, detail='Template not found')
+    return FileResponse(template_path, media_type='application/vnd.openxmlformats-officedocument.wordprocessingml.document', filename=f'{template_id}.docx')
 
 @app.post('/documents/{template_id}')
 async def generate_document(template_id: str, data: UploadFile = File(...)):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,9 +7,14 @@ export default function App() {
   const [hint, setHint] = useState('minimal');
   const [jsonData, setJsonData] = useState('{\n  "customer": {"name": "Alice"}\n}');
   const [message, setMessage] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [downloadUrl, setDownloadUrl] = useState('');
 
   async function createTemplate(e) {
     e.preventDefault();
+    setCreating(true);
+    setMessage('');
+    setDownloadUrl('');
     const res = await fetch('/templates', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -17,7 +22,9 @@ export default function App() {
     });
     const data = await res.json();
     setTemplateId(data.template_id);
+    setDownloadUrl(data.download_url);
     setMessage(`Created template ${data.template_id}`);
+    setCreating(false);
   }
 
   async function generateDocument(e) {
@@ -55,8 +62,13 @@ export default function App() {
               <option value="classic">Classic</option>
             </select>
           </div>
-          <button type="submit">Create</button>
+          <button type="submit" disabled={creating}>{creating ? 'Creating...' : 'Create'}</button>
         </form>
+        {downloadUrl && (
+          <p>
+            <a href={downloadUrl}>Download template</a>
+          </p>
+        )}
       </section>
 
       <section className="card">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,12 +1,26 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import App from './App';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 
 describe('App', () => {
   it('renders create template form', () => {
     render(<App />);
     expect(screen.getByText(/Create Template/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Style Description/i)).toBeInTheDocument();
+  });
+
+  it('shows progress and download link when creating template', async () => {
+    const mockResp = { template_id: 'abc', download_url: '/templates/abc' };
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve(mockResp) });
+
+    render(<App />);
+    fireEvent.click(screen.getAllByText('Create')[0]);
+
+    expect(screen.getByText(/Creating.../i)).toBeInTheDocument();
+    await screen.findByText('Download template');
+    expect(screen.getByRole('link', { name: /download template/i })).toHaveAttribute('href', '/templates/abc');
+    expect(global.fetch).toHaveBeenCalled();
   });
 });

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,11 +10,17 @@ client = TestClient(app)
 
 def test_create_and_generate(tmp_path):
     # create template
-    response = client.post('/templates', data={'style_desc': '', 'hint': ''})
+    response = client.post('/templates', json={'style_desc': 'Sample', 'hint': 'modern'})
     assert response.status_code == 200
-    template_id = response.json()['template_id']
+    data = response.json()
+    template_id = data['template_id']
     template_path = TEMPLATE_DIR / f'{template_id}.docx'
     assert template_path.exists()
+
+    # the download url should return the created file
+    download_url = data['download_url']
+    get_resp = client.get(download_url)
+    assert get_resp.status_code == 200
 
     # generate document
     data = {'name': 'Alice'}
@@ -23,6 +29,13 @@ def test_create_and_generate(tmp_path):
     assert response.status_code == 200
     doc_path = Path(response.json()['document'])
     assert doc_path.exists()
+    # Verify the placeholder was rendered
+    from docx import Document as Doc
+
+    doc = Doc(str(doc_path))
+    text = "\n".join(p.text for p in doc.paragraphs)
+    assert 'Alice' in text
+
     # Clean up
     template_path.unlink()
     doc_path.unlink()


### PR DESCRIPTION
## Summary
- Expose a GET `/templates/{id}` endpoint and return its URL on template creation
- Show progress and present download link when creating templates in the React UI
- Expand tests for template download and frontend progress indicator

## Testing
- `pytest -q`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68adf99a227c8332aace826d04f65c19